### PR TITLE
Package Manager integration/modernization

### DIFF
--- a/Assets/Rhythmify_Scripts/MusicWrapper.cs
+++ b/Assets/Rhythmify_Scripts/MusicWrapper.cs
@@ -20,7 +20,7 @@ namespace Rhythmify {
                 Debug.Break();
             }
 
-            audioSource = gameObject.audio;
+            audioSource = gameObject.GetComponent<AudioSource>();
             audioClip = audioSource.clip;
         }
     

--- a/Assets/Rhythmify_Scripts/rhythmObject/ChangeColors.cs
+++ b/Assets/Rhythmify_Scripts/rhythmObject/ChangeColors.cs
@@ -14,6 +14,11 @@ namespace Rhythmify {
         public int[] indices;
         public int offset;
         public bool shared;
+        private new Renderer renderer;
+
+		override protected void init() {
+			renderer = GetComponent<Renderer>();
+		}
 
         override protected void rhythmUpdate(int beat) {
             int size = colorTransitions.Length;

--- a/Assets/Rhythmify_Scripts/rhythmObject/_AbstractRhythmObject.cs
+++ b/Assets/Rhythmify_Scripts/rhythmObject/_AbstractRhythmObject.cs
@@ -29,7 +29,7 @@ namespace Rhythmify {
 
             GameObject bgmContainer = GameObject.FindGameObjectWithTag("Rhythmify_Music");
         
-            audioSource = bgmContainer.audio;
+            audioSource = bgmContainer.GetComponent<AudioSource>();
             audioClip = audioSource.clip;
         
             BPM = bgmContainer.GetComponent<MusicWrapper>().BPM;

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "com.gkxd.rhythmify",
+  "displayName": "Rhythmify",
+  "version": "1.0.8",
+  "description": "A Rhythm Syncing Implementation for Unity",
+  "author": "Gkxd",
+  "dependencies": {
+    "com.unity.modules.audio": "5.6.0"
+  },
+  "repository": {
+        "type": "git",
+        "url": "git@github.com:Gkxd/Rhythmify.git"
+  },
+  "license": "MIT"
+}

--- a/Assets/package.json.meta
+++ b/Assets/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1d031b00840bdd347921307993adfc5a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a Package Manifest to the Assets folder, hopefully allowing access from the Package Manager in 2019.3. (Manifest is untested, and the dependency on com.unity.modules.audio probably has a bad version number.)

In order for it to work in 2019.2 even, had to replace all uses of `gameObject.renderer `and `gameObject.audio` with equivalent `GetComponent<...>()` calls, overriding `init()` whenever needed.

It'll be a pretty clunky package still--none of the samples have been sorted into the proper `Samples~` folder--but still. Packagized.